### PR TITLE
Add example for ParseApi.AIParse (Extracts data from a document using AI based on a simple JSON template.)

### DIFF
--- a/Examples/GroupDocs.Parser.Cloud.Examples.CSharp/ParseOperations/AIParseDocument.cs
+++ b/Examples/GroupDocs.Parser.Cloud.Examples.CSharp/ParseOperations/AIParseDocument.cs
@@ -1,0 +1,38 @@
+using System;
+using GroupDocs.Parser.Cloud.Sdk.Api;
+using GroupDocs.Parser.Cloud.Sdk.Client;
+using GroupDocs.Parser.Cloud.Sdk.Model;
+using GroupDocs.Parser.Cloud.Sdk.Model.Requests;
+
+namespace GroupDocs.Parser.Cloud.Examples.CSharp
+{
+    public class AIParseDocument
+    {
+        public static void Run()
+        {
+            var config = new Configuration(Common.MyAppSid, Common.MyAppKey);
+            var api = new ParseApi(config);
+
+            var options = new AIParseOptions
+            {
+                FileInfo = new FileInfo
+                {
+                    FilePath = "invoices/invoice.pdf",
+                    StorageName = Common.MyStorage
+                },
+                Template = new
+                {
+                    InvoiceNumber = "",
+                    InvoiceDate = "",
+                    TotalAmount = ""
+                }
+            };
+
+            var request = new AIParseRequest(options);
+            var result = api.AIParse(request);
+
+            Console.WriteLine("AI Parse result:");
+            Console.WriteLine(result);
+        }
+    }
+}


### PR DESCRIPTION
Extracts data from a document using AI based on a simple JSON template.

Target file: `Examples/GroupDocs.Parser.Cloud.Examples.CSharp/ParseOperations/AIParseDocument.cs`